### PR TITLE
fix for "Failed to issue BanAsync: Expected type number in UserIds"

### DIFF
--- a/Server/Server-Banning API.luau
+++ b/Server/Server-Banning API.luau
@@ -185,7 +185,7 @@ return function(Vargs)
 	local function GetUserIdFromRecord(check)
 		if type(check) == "table" then
 			if check.UserId then
-				return check.UserId
+				return tonumber(check.UserId)
 			end
 		elseif type(check) == "string" then
 			local cName, cId = string.match(check, "(.*):(.*)")


### PR DESCRIPTION
used `tonumber()` on `check.UserId` since sometimes (or all of the time) it returns a string instead of a number, which is a bit problematic:
![image](https://github.com/user-attachments/assets/1bd620f9-7a5c-4ca1-a05a-0546b0266286)


tested on my game after changing it, works well