### PR TITLE
Remove workaround in ChannelTabs plugin

### DIFF
--- a/Server/Server-ChannelTab.luau
+++ b/Server/Server-ChannelTab.luau
@@ -4,6 +4,7 @@
 	Description: This plugin will add an "Admins" channel tab and automatically remove unused team channel tabs.
 	Place in a ModuleScript under Adonis_Loader > Config > Plugins and named "Server-ChannelTab"
 --]]
+
 return function(Vargs)
 	local server, service = Vargs.Server, Vargs.Service
 
@@ -23,17 +24,6 @@ return function(Vargs)
 	end
 	
 	local TextChannels = TextChatService and TextChatService:FindFirstChild("TextChannels")
-	
-	-- Workaround for tabs not disappearing once removed from it
-	local function refreshChatWindow(plr: Player)
-		Remote.LoadCode(plr, [[
-		local TextChannels = game.TextChatService.TextChannels
-		
-		TextChannels.Parent = nil
-		task.wait()
-		TextChannels.Parent = game.TextChatService
-		]])
-	end
 	
 	local adminChannel = service.New("TextChannel", {
 		Name = "Admins";
@@ -69,7 +59,6 @@ return function(Vargs)
 			
 			
 			if not plr.Team then
-				refreshChatWindow(plr)
 				teamName = nil
 			end
 		end)
@@ -88,7 +77,6 @@ return function(Vargs)
 		local plr = channel:FindFirstChild(p.Name)
 		if channel and plr then
 			plr:Destroy()
-			refreshChatWindow(p)
 		end
 	end
 end


### PR DESCRIPTION
[Roblox finally fixed this issue so now this function isnt needed](https://devforum.roblox.com/t/textchannels-channel-tab-does-not-disappear-when-players-textsource-is-removed-from-a-textchannel/3249983/16)